### PR TITLE
Created Cocoa Touch Framework proj for Carthage-compat

### DIFF
--- a/GRKContainerViewController.h
+++ b/GRKContainerViewController.h
@@ -1,0 +1,29 @@
+//
+//  GRKContainerViewController.h
+//
+//  Created by Cap'n Slipp on 6/27/16.
+//  Copyright (c) 2013, 2014 Levi Brown <mailto:levigroker@gmail.com>
+//  This work is licensed under the Creative Commons Attribution 3.0
+//  Unported License. To view a copy of this license, visit
+//  http://creativecommons.org/licenses/by/3.0/ or send a letter to Creative
+//  Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041,
+//  USA.
+//
+//  The above attribution and the included license must accompany any version
+//  of the source code. Visible attribution in any binary distributable
+//  including this work (or derivatives) is not required, but would be
+//  appreciated.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for GRKContainerViewController.
+FOUNDATION_EXPORT double GRKContainerViewControllerVersionNumber = 1.2;
+
+//! Project version string for GRKContainerViewController.
+FOUNDATION_EXPORT const unsigned char GRKContainerViewControllerVersionString[] = "1.2";
+
+
+#import <GRKContainerViewController/GRKContainerViewController.h>
+
+

--- a/GRKContainerViewController.xcodeproj/project.pbxproj
+++ b/GRKContainerViewController.xcodeproj/project.pbxproj
@@ -1,0 +1,293 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		FAD57D8F1D21E91F001A76C1 /* GRKContainerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD57D8E1D21E91F001A76C1 /* GRKContainerViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FAD57D971D21E992001A76C1 /* GRKContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FAD57D961D21E992001A76C1 /* GRKContainerViewController.m */; };
+		FAD57DAE1D21EDCD001A76C1 /* GRKContainerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD57DAD1D21EDCD001A76C1 /* GRKContainerViewController.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		FAD57D8B1D21E91F001A76C1 /* GRKContainerViewController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GRKContainerViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAD57D8E1D21E91F001A76C1 /* GRKContainerViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GRKContainerViewController.h; sourceTree = "<group>"; };
+		FAD57D901D21E91F001A76C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FAD57D961D21E992001A76C1 /* GRKContainerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GRKContainerViewController.m; sourceTree = "<group>"; };
+		FAD57DAD1D21EDCD001A76C1 /* GRKContainerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GRKContainerViewController.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FAD57D871D21E91F001A76C1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		FAD57D811D21E91F001A76C1 = {
+			isa = PBXGroup;
+			children = (
+				FAD57DAD1D21EDCD001A76C1 /* GRKContainerViewController.h */,
+				FAD57D8D1D21E91F001A76C1 /* GRKContainerViewController */,
+				FAD57D8C1D21E91F001A76C1 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		FAD57D8C1D21E91F001A76C1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FAD57D8B1D21E91F001A76C1 /* GRKContainerViewController.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FAD57D8D1D21E91F001A76C1 /* GRKContainerViewController */ = {
+			isa = PBXGroup;
+			children = (
+				FAD57D901D21E91F001A76C1 /* Info.plist */,
+				FAD57D8E1D21E91F001A76C1 /* GRKContainerViewController.h */,
+				FAD57D961D21E992001A76C1 /* GRKContainerViewController.m */,
+			);
+			path = GRKContainerViewController;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		FAD57D881D21E91F001A76C1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAD57DAE1D21EDCD001A76C1 /* GRKContainerViewController.h in Headers */,
+				FAD57D8F1D21E91F001A76C1 /* GRKContainerViewController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		FAD57D8A1D21E91F001A76C1 /* GRKContainerViewController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FAD57D931D21E91F001A76C1 /* Build configuration list for PBXNativeTarget "GRKContainerViewController" */;
+			buildPhases = (
+				FAD57D861D21E91F001A76C1 /* Sources */,
+				FAD57D871D21E91F001A76C1 /* Frameworks */,
+				FAD57D881D21E91F001A76C1 /* Headers */,
+				FAD57D891D21E91F001A76C1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GRKContainerViewController;
+			productName = GRKContainerViewController;
+			productReference = FAD57D8B1D21E91F001A76C1 /* GRKContainerViewController.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		FAD57D821D21E91F001A76C1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = "Cap'n Slipp";
+				TargetAttributes = {
+					FAD57D8A1D21E91F001A76C1 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+				};
+			};
+			buildConfigurationList = FAD57D851D21E91F001A76C1 /* Build configuration list for PBXProject "GRKContainerViewController" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = FAD57D811D21E91F001A76C1;
+			productRefGroup = FAD57D8C1D21E91F001A76C1 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				FAD57D8A1D21E91F001A76C1 /* GRKContainerViewController */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		FAD57D891D21E91F001A76C1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		FAD57D861D21E91F001A76C1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAD57D971D21E992001A76C1 /* GRKContainerViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		FAD57D911D21E91F001A76C1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1.2;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FAD57D921D21E91F001A76C1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1.2;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		FAD57D941D21E91F001A76C1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GRKContainerViewController/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.levigroker.GRKContainerViewController;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FAD57D951D21E91F001A76C1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GRKContainerViewController/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.levigroker.GRKContainerViewController;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		FAD57D851D21E91F001A76C1 /* Build configuration list for PBXProject "GRKContainerViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FAD57D911D21E91F001A76C1 /* Debug */,
+				FAD57D921D21E91F001A76C1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FAD57D931D21E91F001A76C1 /* Build configuration list for PBXNativeTarget "GRKContainerViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FAD57D941D21E91F001A76C1 /* Debug */,
+				FAD57D951D21E91F001A76C1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = FAD57D821D21E91F001A76C1 /* Project object */;
+}

--- a/GRKContainerViewController.xcodeproj/xcshareddata/xcschemes/GRKContainerViewController.xcscheme
+++ b/GRKContainerViewController.xcodeproj/xcshareddata/xcschemes/GRKContainerViewController.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FAD57D8A1D21E91F001A76C1"
+               BuildableName = "GRKContainerViewController.framework"
+               BlueprintName = "GRKContainerViewController"
+               ReferencedContainer = "container:GRKContainerViewController.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FAD57D8A1D21E91F001A76C1"
+            BuildableName = "GRKContainerViewController.framework"
+            BlueprintName = "GRKContainerViewController"
+            ReferencedContainer = "container:GRKContainerViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FAD57D8A1D21E91F001A76C1"
+            BuildableName = "GRKContainerViewController.framework"
+            BlueprintName = "GRKContainerViewController"
+            ReferencedContainer = "container:GRKContainerViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/GRKContainerViewController/Info.plist
+++ b/GRKContainerViewController/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
* Created a new `GRKContainerViewController.xcodeproj` from the Cocoa Touch Framework template.
* Added the existing `GRKContainerViewController/GRKContainerViewController.h`/`.m` files to the project.
* Set up the template-generated header with the current version number (1.2) and an import for `<GRKContainerViewController/GRKContainerViewController.h>`.
* Changed `Info.plist`'s `CFBundleShortVersionString` to also (in addition to `CFBundleVersion`) use the build setting `CURRENT_PROJECT_VERSION`'s value.
* Changed the `CURRENT_PROJECT_VERSION` build setting to the current version (1.2).
* Shared the “GRKContainerViewController” scheme (required by Carthage).
* Set iOS Deployment Target to 8.0, the oldest iOS version that supports dynamic frameworks.

Checked and the framework works properly in Objective-C & Swift app projects, via a `Cartfile` with `github "capnslipp/GRKContainerViewController" "capnslipp-carthage-compat"`.  Once merged and tagged with a new version (1.2.1?), `Cartfile` usage will be possible with just `github "levigroker/GRKContainerViewController"`.